### PR TITLE
Update includes for various Android versions

### DIFF
--- a/src/haptics/haptics.c
+++ b/src/haptics/haptics.c
@@ -17,7 +17,12 @@
 *
 * LICENSE@@@ */
 
+#if ANDROID_VERSION_MAJOR <= 5
 #include <android/hardware_legacy/vibrator.h>
+#else
+#include <android/hardware/vibrator.h>
+#endif
+
 #include <glib.h>
 #include <stdlib.h>
 #include <nyx/nyx_module.h>


### PR DESCRIPTION
Fixes:
 /home/herriemerim/LuneOS/warrior/webos-ports/tmp-glibc/work/hammerhead-webos-linux-gnueabi/nyx-modules-hybris/0.1.0-1+gitAUTOINC+3b63f1d929-r0/git/src/haptics/haptics.c:20:10: fatal error: android/hardware_legacy/vibrator.h: No such file or directory
|  #include <android/hardware_legacy/vibrator.h>

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>