### PR TITLE
Adapt for Android >= 9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,10 @@ include(FindPkgConfig)
 
 include(webOS/webOS)
 
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/machine.cmake)
+	include(${CMAKE_CURRENT_SOURCE_DIR}/machine.cmake)
+endif()
+
 webos_modules_init(1 6 2)
 webos_component(1 0 0)
 webos_include_install_paths()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,7 +85,20 @@ macro(nyx_create_module module)
 	install(TARGETS ${module} DESTINATION ${NYX_MODULE_DIR})
 endmacro()
 
-add_subdirectory(led_controller)
-add_subdirectory(device_info)
-add_subdirectory(system)
-add_subdirectory(haptics)
+# only include the module if it wasn't built with native Nyx module
+
+if(NOT NYXMOD_OW_LED)
+	add_subdirectory(led_controller)
+endif()
+
+if(NOT NYXMOD_OW_DEVICEINFO)
+	add_subdirectory(device_info)
+endif()
+
+if(NOT NYXMOD_OW_SYSTEM)
+	add_subdirectory(system)
+endif()
+
+if(NOT NYXMOD_OW_HAPTICS)
+	add_subdirectory(haptics)
+endif()

--- a/src/haptics/haptics.c
+++ b/src/haptics/haptics.c
@@ -45,6 +45,10 @@ NYX_DECLARE_MODULE(NYX_DEVICE_HAPTICS, "Haptics")
 
 nyx_error_t nyx_module_open (nyx_instance_t instance, nyx_device_t** device_ptr)
 {
+#if (ANDROID_VERSION_MAJOR >= 9)
+	return NYX_ERROR_DEVICE_NOT_EXIST;
+#endif
+
 	if (!vibrator_exists())
 		return NYX_ERROR_DEVICE_NOT_EXIST;
 


### PR DESCRIPTION
This avoid a crash in libhybris, as vibrator API has been removed from libhardware_legacy since then.